### PR TITLE
Fix: Handle error while unmounting Droppable ref

### DIFF
--- a/src/droppable.tsx
+++ b/src/droppable.tsx
@@ -74,7 +74,7 @@ export function droppable(
     };
 
     handleRef = (element: any) => {
-      if (element.getNode) {
+      if (element && element.getNode) {
         this.element = element.getNode();
       } else {
         this.element = element;


### PR DESCRIPTION
Added check in handelRef method to fix error if the Droppable element is unmounted