### PR TITLE
Fix: DnDContext.unregisterDroppable function is not working

### DIFF
--- a/src/dragAndDropContext.tsx
+++ b/src/dragAndDropContext.tsx
@@ -106,7 +106,7 @@ function createDndContext(): DragAndDropContext {
 
     unregisterDroppable = (id: DndId) => {
       this.setState(({ droppables }) => ({
-        droppables: droppable.filter(droppable => droppable.id !== id)
+        droppables: droppables.filter(droppable => droppable.id !== id)
       }));
     };
 

--- a/src/dragAndDropContext.tsx
+++ b/src/dragAndDropContext.tsx
@@ -105,8 +105,8 @@ function createDndContext(): DragAndDropContext {
     };
 
     unregisterDroppable = (id: DndId) => {
-      this.setState(({ draggables }) => ({
-        draggables: draggables.filter(draggable => draggable.id !== id)
+      this.setState(({ droppables }) => ({
+        droppables: droppable.filter(droppable => droppable.id !== id)
       }));
     };
 


### PR DESCRIPTION
I noticed when unregisteringDroppables it's filtering to the state of the `draggables` instead of `droppables`