### PR TITLE
Corrected peerDependencies. There is no React Native v50.0.0 yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "create-react-context": "^0.2.3"
   },
   "peerDependencies": {
-    "react-native": ">=50.0.0"
+    "react-native": ">=0.50.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.16",


### PR DESCRIPTION
This was causing issues when using npm with a project using easy-dnd and causes `npm install` to fail.